### PR TITLE
[TERR-359] Remove hard dependency on yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "esnet-networkmap-panel",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Network Map Panel",
   "repository": "https://github.com/esnet/grafana-esnet-networkmap-panel",
   "scripts": {
-    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('You must use Yarn to install, not NPM')\"",
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "build_dts": "tsc -d --declarationDir dist --declarationMap --emitDeclarationOnly",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
This causes a hard dependency in all downstream code on yarn, and means we're de-facto dictating a package manager. This breaks downstream builds.